### PR TITLE
Replace boilerplate README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,43 +1,19 @@
-# Astro Starter Kit: Minimal
+# Personal Site
+
+Personal portfolio site at [dimitriberardi.com](https://dimitriberardi.com). Built with Astro and Tailwind CSS v4. Multiple visual skins, switchable via a drawer.
+
+## Stack
+
+- [Astro](https://astro.build) v5
+- [Tailwind CSS](https://tailwindcss.com) v4
+
+## Dev
 
 ```sh
-npm create astro@latest -- --template minimal
+npm install
+npm run dev -- --host
 ```
 
-> 🧑‍🚀 **Seasoned astronaut?** Delete this file. Have fun!
+## Skins
 
-## 🚀 Project Structure
-
-Inside of your Astro project, you'll see the following folders and files:
-
-```text
-/
-├── public/
-├── src/
-│   └── pages/
-│       └── index.astro
-└── package.json
-```
-
-Astro looks for `.astro` or `.md` files in the `src/pages/` directory. Each page is exposed as a route based on its file name.
-
-There's nothing special about `src/components/`, but that's where we like to put any Astro/React/Vue/Svelte/Preact components.
-
-Any static assets, like images, can be placed in the `public/` directory.
-
-## 🧞 Commands
-
-All commands are run from the root of the project, from a terminal:
-
-| Command                   | Action                                           |
-| :------------------------ | :----------------------------------------------- |
-| `npm install`             | Installs dependencies                            |
-| `npm run dev`             | Starts local dev server at `localhost:4321`      |
-| `npm run build`           | Build your production site to `./dist/`          |
-| `npm run preview`         | Preview your build locally, before deploying     |
-| `npm run astro ...`       | Run CLI commands like `astro add`, `astro check` |
-| `npm run astro -- --help` | Get help using the Astro CLI                     |
-
-## 👀 Want to learn more?
-
-Feel free to check [our documentation](https://docs.astro.build) or jump into our [Discord server](https://astro.build/chat).
+Skins live in `src/skins/`. The active default is set in `src/config/skins.ts`.


### PR DESCRIPTION
Replaces the default Astro starter README with a minimal project-specific one.

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)