### PR TITLE
Fix drawer visible during iOS Chrome viewport shift on scroll

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,36 @@
+# Personal Site
+
+Astro v5 static site. Tailwind CSS v4 via `@tailwindcss/vite` (no config file).
+
+## Stack
+
+- `src/skins/` - pure skin templates (one per visual theme)
+- `src/config/skins.ts` - skin registry and `DEFAULT_SKIN`
+- `src/pages/index.astro` - thin wrapper importing the default skin
+- `src/pages/preview/<id>.astro` - thin wrappers for each skin (one file each)
+- `src/components/` - shared components (SkinDrawer, etc.)
+- `src/layouts/Layout.astro` - base HTML shell (no skin-specific styling)
+
+## Dev Server
+
+```bash
+npm run dev -- --host
+```
+
+Dev toolbar is disabled. To re-enable: `npx astro preferences enable devToolbar`
+
+## Development Workflow
+
+- `master` is stable and deployable
+- Feature branches required for non-trivial changes (new skins, refactors, bug fixes)
+- PRs required before merge - self-review expected
+- GitHub Issues for bugs and future features
+- Testing: visual check in browser across affected skins
+- No CI/CD currently
+
+## Key Conventions
+
+- Skin `<style>` tags must use `is:global` - Astro scopes component styles by default, which breaks `body {}` and pseudo-element rules
+- Do not add background or text color classes to `Layout.astro` body - skins own those styles
+- Adding a skin requires: new `src/skins/<Name>.astro`, new `src/pages/preview/<id>.astro`, entry in `src/config/skins.ts`
+- Changing the default skin: update `DEFAULT_SKIN` in `skins.ts` AND the import in `src/pages/index.astro`

--- a/src/components/SkinDrawer.astro
+++ b/src/components/SkinDrawer.astro
@@ -25,7 +25,7 @@ const { current } = Astro.props;
 <!-- Drawer -->
 <div
   id="skin-drawer"
-  class="fixed bottom-0 left-0 right-0 z-50 bg-slate-950/95 backdrop-blur-xl border-t border-white/10 rounded-t-2xl shadow-2xl translate-y-full transition-transform duration-300 ease-out"
+  class="fixed bottom-0 left-0 right-0 z-50 bg-slate-950/95 backdrop-blur-xl border-t border-white/10 rounded-t-2xl shadow-2xl translate-y-full invisible transition-transform duration-300 ease-out"
 >
   <div class="flex items-center justify-between px-6 pt-5 pb-4 border-b border-white/10">
     <span class="text-white font-semibold">Design Skins</span>
@@ -60,6 +60,7 @@ const { current } = Astro.props;
   const close = document.getElementById('skin-close')!;
 
   function open() {
+    drawer.classList.remove('invisible');
     drawer.classList.remove('translate-y-full');
     backdrop.classList.remove('hidden');
   }
@@ -67,6 +68,9 @@ const { current } = Astro.props;
   function shut() {
     drawer.classList.add('translate-y-full');
     backdrop.classList.add('hidden');
+    drawer.addEventListener('transitionend', () => {
+      drawer.classList.add('invisible');
+    }, { once: true });
   }
 
   toggle.addEventListener('click', open);


### PR DESCRIPTION
## Summary
- Adds `invisible` (visibility: hidden) to the drawer's initial state alongside `translate-y-full`
- Removes `invisible` on open, adds it back after the close transition ends via `transitionend`
- This ensures the drawer is truly hidden from rendering when closed, not just translated offscreen — preventing it from bleeding into view when iOS Chrome's viewport reflows during scroll

## Root cause
When iOS Chrome's browser UI collapses on scroll, the visual viewport expands and `position: fixed` elements reflow. `translate-y-full` positions the drawer exactly at the viewport boundary, so the repaint could briefly expose it.

## Test plan
- [x] Open on iOS Chrome, scroll to collapse browser UI — drawer should not be visible
- [x] Tap "Skin" button — drawer opens and closes with animation as expected
- [x] Tap backdrop — drawer closes correctly

Closes #8