### PR TITLE
Improve promotion styling across skins

### DIFF
--- a/src/components/PromotionGroup.astro
+++ b/src/components/PromotionGroup.astro
@@ -1,0 +1,42 @@
+---
+import type { PromotionGroup } from '../data/content';
+
+interface Props {
+  group: PromotionGroup;
+  titleClass: string;
+  companyClass: string;
+  periodClass: string;
+  bulletClass: string;
+  prevRoleClass: string;
+  connectorLineClass: string;
+  badgeClass: string;
+}
+
+const { group, titleClass, companyClass, periodClass, bulletClass, prevRoleClass, connectorLineClass, badgeClass } = Astro.props;
+const [current, ...previous] = group.roles;
+---
+
+<div class="flex items-start justify-between gap-4 flex-wrap mb-1">
+  <h3 class={titleClass}>{current.title}</h3>
+  <span class={periodClass}>{current.period}</span>
+</div>
+<p class={`text-sm mb-3 ${companyClass}`}>{group.company} · {group.location}</p>
+{current.bullets.length > 0 && (
+  <ul class={`text-sm space-y-2 list-disc list-inside leading-relaxed mb-4 ${bulletClass}`}>
+    {current.bullets.map(b => <li>{b}</li>)}
+  </ul>
+)}
+
+{previous.map(role => (
+  <div>
+    <div class="flex items-center gap-3 mb-3">
+      <div class={`flex-1 border-t border-dashed ${connectorLineClass}`}></div>
+      <span class={`text-xs px-2 py-0.5 rounded ${badgeClass}`}>Promoted</span>
+      <div class={`flex-1 border-t border-dashed ${connectorLineClass}`}></div>
+    </div>
+    <div class="flex items-start justify-between gap-4 flex-wrap">
+      <span class={`text-sm font-medium ${prevRoleClass}`}>{role.title}</span>
+      <span class={periodClass}>{role.period}</span>
+    </div>
+  </div>
+))}

--- a/src/data/content.ts
+++ b/src/data/content.ts
@@ -29,20 +29,52 @@ export const skills = {
   practices: ['RESTful API Design', 'Unit & Integration Testing', 'CI/CD', 'Agile', 'System Design', 'ADRs'],
 };
 
-export const experience = [
+export type RegularJob = {
+  company: string;
+  location: string;
+  period: string;
+  current?: boolean;
+  title: string;
+  bullets: string[];
+};
+
+export type PromotionGroup = {
+  type: 'promotion';
+  company: string;
+  location: string;
+  current?: boolean;
+  roles: Array<{
+    title: string;
+    period: string;
+    bullets: string[];
+  }>;
+};
+
+export type ExperienceEntry = RegularJob | PromotionGroup;
+
+export const experience: ExperienceEntry[] = [
   {
-    title: 'Software Engineer II',
+    type: 'promotion',
     company: 'Kahuna Workforce Solutions',
     location: 'Remote',
-    period: 'Dec 2024 – Present',
     current: true,
-    promotion: 'Promoted from Software Engineer · Dec 2025',
-    bullets: [
-      'Designed and shipped the full backend API surface for Ladder in C# / ASP.NET Core — from greenfield through first customer launch, as one of three backend engineers.',
-      'Implemented the core data layer — Elasticsearch for read performance, SQL as source of truth — using Entity Framework Core across the Ladder data domain.',
-      'Designed the integration and unit test suite using xUnit and Moq, leveraging WebApplicationFactory to test against real ES/DB.',
-      'Leading backend architecture for a major new feature — driving design reviews and cross-functional alignment across product, QA, and engineering.',
-      'Established a documentation practice: feature specs, ADRs, and a shared technical blog.',
+    roles: [
+      {
+        title: 'Software Engineer II',
+        period: 'Dec 2025 – Present',
+        bullets: [
+          'Designed and shipped the full backend API surface for Ladder in C# / ASP.NET Core — from greenfield through first customer launch, as one of three backend engineers.',
+          'Implemented the core data layer — Elasticsearch for read performance, SQL as source of truth — using Entity Framework Core across the Ladder data domain.',
+          'Designed the integration and unit test suite using xUnit and Moq, leveraging WebApplicationFactory to test against real ES/DB.',
+          'Leading backend architecture for a major new feature — driving design reviews and cross-functional alignment across product, QA, and engineering.',
+          'Established a documentation practice: feature specs, ADRs, and a shared technical blog.',
+        ],
+      },
+      {
+        title: 'Software Engineer',
+        period: 'Dec 2024 – Dec 2025',
+        bullets: [],
+      },
     ],
   },
   {
@@ -50,7 +82,6 @@ export const experience = [
     company: 'Building36',
     location: 'Needham, MA (Hybrid)',
     period: 'Apr 2022 – Nov 2024',
-    current: false,
     bullets: [
       'Led end-to-end delivery of a templated HTML email generation system — backend rendering layer, frontend templates, design docs, and PM/QA coordination through all milestones.',
       'Built full-stack HVAC monitoring features across backend services, data layer, and ASPX frontend.',
@@ -61,7 +92,6 @@ export const experience = [
     company: 'Savant Systems, Energy and Lighting',
     location: 'Hyannis, MA (Hybrid)',
     period: 'Jan 2021 – Mar 2022',
-    current: false,
     bullets: [
       'Implemented a CAN Bus communication layer in Rust and Go — parsing live device telemetry and enabling bidirectional control of the microgrid controller.',
       'Extended a Go RESTful API to enable full CRUD control over HVAC devices, including SQL-to-JSON serialization for downstream consumption.',
@@ -72,7 +102,6 @@ export const experience = [
     company: 'Fidelity Investments',
     location: 'Merrimack, NH (Remote)',
     period: 'Jun – Aug 2020',
-    current: false,
     bullets: [
       'Integrated a third-party vendor (Axway) to automate file transfers to a PostgreSQL database via FTPS, replacing a manual process.',
     ],
@@ -82,7 +111,6 @@ export const experience = [
     company: 'Bose Corporation',
     location: 'Framingham, MA (On-Site)',
     period: 'May 2019 – Jan 2020',
-    current: false,
     bullets: [
       'Designed unit test infrastructure using Google Test Framework.',
       'Owned codebase migration from SVN to GitHub, updating build configuration across Make and CMake files.',

--- a/src/skins/Aurora.astro
+++ b/src/skins/Aurora.astro
@@ -1,6 +1,7 @@
 ---
 import Layout from '../layouts/Layout.astro';
 import SkinDrawer from '../components/SkinDrawer.astro';
+import PromotionGroup from '../components/PromotionGroup.astro';
 import { personal, about, skills, experience, education, gameDev, hobbies } from '../data/content';
 ---
 
@@ -90,20 +91,34 @@ import { personal, about, skills, experience, education, gameDev, hobbies } from
     <div class="max-w-5xl mx-auto">
       <h2 class="text-3xl font-bold mb-16 text-white">Experience</h2>
       <div class="space-y-6">
-        {experience.map(job => (
-          <div class={`bg-white/5 backdrop-blur-md border rounded-2xl p-6 ${job.current ? 'border-cyan-500/40' : 'border-white/10'}`}>
-            <div class="flex items-start justify-between gap-4 flex-wrap mb-1">
-              <h3 class="text-lg font-semibold text-white">{job.title}</h3>
-              <span class="text-sm text-white/40">{job.period}</span>
+        {experience.map(entry => (
+          entry.type === 'promotion' ? (
+            <div class={`bg-white/5 backdrop-blur-md border rounded-2xl p-6 ${entry.current ? 'border-cyan-500/40' : 'border-white/10'}`}>
+              <PromotionGroup
+                group={entry}
+                titleClass="text-lg font-semibold text-white"
+                companyClass={entry.current ? 'text-cyan-400' : 'text-white/40'}
+                periodClass="text-sm text-white/40"
+                bulletClass="text-white/50"
+                prevRoleClass="text-white/40"
+                connectorLineClass="border-white/10"
+                badgeClass="text-white/30 border border-white/10"
+              />
             </div>
-            <p class={`text-sm ${job.promotion ? 'mb-1' : 'mb-4'} ${job.current ? 'text-cyan-400' : 'text-white/40'}`}>
-              {job.company} · {job.location}
-            </p>
-            {job.promotion && <p class="text-xs text-white/30 mb-4">{job.promotion}</p>}
-            <ul class="text-white/50 text-sm space-y-2 list-disc list-inside leading-relaxed">
-              {job.bullets.map(b => <li>{b}</li>)}
-            </ul>
-          </div>
+          ) : (
+            <div class={`bg-white/5 backdrop-blur-md border rounded-2xl p-6 ${entry.current ? 'border-cyan-500/40' : 'border-white/10'}`}>
+              <div class="flex items-start justify-between gap-4 flex-wrap mb-1">
+                <h3 class="text-lg font-semibold text-white">{entry.title}</h3>
+                <span class="text-sm text-white/40">{entry.period}</span>
+              </div>
+              <p class={`text-sm mb-4 ${entry.current ? 'text-cyan-400' : 'text-white/40'}`}>
+                {entry.company} · {entry.location}
+              </p>
+              <ul class="text-white/50 text-sm space-y-2 list-disc list-inside leading-relaxed">
+                {entry.bullets.map(b => <li>{b}</li>)}
+              </ul>
+            </div>
+          )
         ))}
       </div>
     </div>

--- a/src/skins/Bold.astro
+++ b/src/skins/Bold.astro
@@ -1,6 +1,7 @@
 ---
 import Layout from '../layouts/Layout.astro';
 import SkinDrawer from '../components/SkinDrawer.astro';
+import PromotionGroup from '../components/PromotionGroup.astro';
 import { personal, about, skills, experience, education, gameDev, hobbies } from '../data/content';
 ---
 
@@ -99,20 +100,34 @@ import { personal, about, skills, experience, education, gameDev, hobbies } from
     <div class="max-w-5xl mx-auto">
       <h2 class="text-5xl font-black text-white mb-16 tracking-tight">Experience</h2>
       <div class="space-y-6">
-        {experience.map((job, i) => (
-          <div class="gradient-border rounded-2xl p-6">
-            <div class="flex items-start justify-between gap-4 flex-wrap mb-1">
-              <h3 class="text-lg font-black text-white">{job.title}</h3>
-              <span class="text-sm text-zinc-500 font-mono">{job.period}</span>
+        {experience.map(entry => (
+          entry.type === 'promotion' ? (
+            <div class="gradient-border rounded-2xl p-6">
+              <PromotionGroup
+                group={entry}
+                titleClass="text-lg font-black text-white"
+                companyClass={`font-bold ${entry.current ? 'gradient-text' : 'text-zinc-500'}`}
+                periodClass="text-sm text-zinc-500 font-mono"
+                bulletClass="text-zinc-400"
+                prevRoleClass="text-zinc-500 font-bold"
+                connectorLineClass="border-zinc-800"
+                badgeClass="text-zinc-600 border border-zinc-700"
+              />
             </div>
-            <p class={`text-sm ${job.promotion ? 'mb-1' : 'mb-4'} font-bold ${job.current ? 'gradient-text' : 'text-zinc-500'}`}>
-              {job.company} · {job.location}
-            </p>
-            {job.promotion && <p class="text-xs text-zinc-600 mb-4">{job.promotion}</p>}
-            <ul class="text-zinc-400 text-sm space-y-2 list-disc list-inside leading-relaxed">
-              {job.bullets.map(b => <li>{b}</li>)}
-            </ul>
-          </div>
+          ) : (
+            <div class="gradient-border rounded-2xl p-6">
+              <div class="flex items-start justify-between gap-4 flex-wrap mb-1">
+                <h3 class="text-lg font-black text-white">{entry.title}</h3>
+                <span class="text-sm text-zinc-500 font-mono">{entry.period}</span>
+              </div>
+              <p class={`text-sm mb-4 font-bold ${entry.current ? 'gradient-text' : 'text-zinc-500'}`}>
+                {entry.company} · {entry.location}
+              </p>
+              <ul class="text-zinc-400 text-sm space-y-2 list-disc list-inside leading-relaxed">
+                {entry.bullets.map(b => <li>{b}</li>)}
+              </ul>
+            </div>
+          )
         ))}
       </div>
     </div>

--- a/src/skins/Brutalist.astro
+++ b/src/skins/Brutalist.astro
@@ -1,6 +1,7 @@
 ---
 import Layout from '../layouts/Layout.astro';
 import SkinDrawer from '../components/SkinDrawer.astro';
+import PromotionGroup from '../components/PromotionGroup.astro';
 import { personal, about, skills, experience, education, gameDev, hobbies } from '../data/content';
 ---
 
@@ -113,20 +114,34 @@ import { personal, about, skills, experience, education, gameDev, hobbies } from
     <div class="max-w-5xl mx-auto">
       <h2 class="text-5xl font-black mb-16 uppercase tracking-tighter">Experience</h2>
       <div class="space-y-6">
-        {experience.map((job, i) => (
-          <div class={`brute-card p-6 ${job.current ? 'bg-yellow-400' : 'bg-white'}`}>
-            <div class="flex items-start justify-between gap-4 flex-wrap mb-2">
-              <h3 class="text-lg font-black uppercase tracking-tight">{job.title}</h3>
-              <span class="text-sm font-mono font-bold border border-black px-2 py-0.5">{job.period}</span>
+        {experience.map(entry => (
+          entry.type === 'promotion' ? (
+            <div class={`brute-card p-6 ${entry.current ? 'bg-yellow-400' : 'bg-white'}`}>
+              <PromotionGroup
+                group={entry}
+                titleClass="text-lg font-black uppercase tracking-tight"
+                companyClass="font-bold uppercase tracking-wide"
+                periodClass="text-sm font-mono font-bold"
+                bulletClass="text-stone-700"
+                prevRoleClass="text-stone-600 font-bold uppercase tracking-wide"
+                connectorLineClass="border-black/20"
+                badgeClass="text-stone-500 font-bold uppercase text-xs border border-stone-400"
+              />
             </div>
-            <p class={`text-sm font-bold ${job.promotion ? 'mb-1' : 'mb-4'} uppercase tracking-wide`}>
-              {job.company} · {job.location}
-            </p>
-            {job.promotion && <p class="text-xs text-stone-500 mb-4">{job.promotion}</p>}
-            <ul class="text-stone-700 text-sm space-y-2 list-disc list-inside leading-relaxed">
-              {job.bullets.map(b => <li>{b}</li>)}
-            </ul>
-          </div>
+          ) : (
+            <div class={`brute-card p-6 ${entry.current ? 'bg-yellow-400' : 'bg-white'}`}>
+              <div class="flex items-start justify-between gap-4 flex-wrap mb-2">
+                <h3 class="text-lg font-black uppercase tracking-tight">{entry.title}</h3>
+                <span class="text-sm font-mono font-bold border border-black px-2 py-0.5">{entry.period}</span>
+              </div>
+              <p class="text-sm font-bold mb-4 uppercase tracking-wide">
+                {entry.company} · {entry.location}
+              </p>
+              <ul class="text-stone-700 text-sm space-y-2 list-disc list-inside leading-relaxed">
+                {entry.bullets.map(b => <li>{b}</li>)}
+              </ul>
+            </div>
+          )
         ))}
       </div>
     </div>

--- a/src/skins/Dark.astro
+++ b/src/skins/Dark.astro
@@ -1,6 +1,7 @@
 ---
 import Layout from '../layouts/Layout.astro';
 import SkinDrawer from '../components/SkinDrawer.astro';
+import PromotionGroup from '../components/PromotionGroup.astro';
 import { personal, about, skills, experience, education, gameDev, hobbies } from '../data/content';
 ---
 
@@ -78,20 +79,34 @@ import { personal, about, skills, experience, education, gameDev, hobbies } from
     <div class="max-w-5xl mx-auto">
       <h2 class="text-3xl font-bold mb-16 text-slate-100">Experience</h2>
       <div class="space-y-10">
-        {experience.map(job => (
-          <div class={`border-l-2 pl-6 ${job.current ? 'border-emerald-500' : 'border-slate-700'}`}>
-            <div class="flex items-start justify-between gap-4 flex-wrap mb-1">
-              <h3 class="text-lg font-semibold text-slate-100">{job.title}</h3>
-              <span class="text-sm text-slate-500">{job.period}</span>
+        {experience.map(entry => (
+          entry.type === 'promotion' ? (
+            <div class={`border-l-2 pl-6 ${entry.current ? 'border-emerald-500' : 'border-slate-700'}`}>
+              <PromotionGroup
+                group={entry}
+                titleClass="text-lg font-semibold text-slate-100"
+                companyClass={entry.current ? 'text-emerald-400' : 'text-slate-400'}
+                periodClass="text-sm text-slate-500"
+                bulletClass="text-slate-400"
+                prevRoleClass="text-slate-400"
+                connectorLineClass="border-slate-700"
+                badgeClass="text-slate-600 border border-slate-700"
+              />
             </div>
-            <p class={`text-sm ${job.promotion ? 'mb-1' : 'mb-3'} ${job.current ? 'text-emerald-400' : 'text-slate-400'}`}>
-              {job.company} · {job.location}
-            </p>
-            {job.promotion && <p class="text-xs text-slate-600 mb-3">{job.promotion}</p>}
-            <ul class="text-slate-400 text-sm space-y-2 list-disc list-inside leading-relaxed">
-              {job.bullets.map(b => <li>{b}</li>)}
-            </ul>
-          </div>
+          ) : (
+            <div class={`border-l-2 pl-6 ${entry.current ? 'border-emerald-500' : 'border-slate-700'}`}>
+              <div class="flex items-start justify-between gap-4 flex-wrap mb-1">
+                <h3 class="text-lg font-semibold text-slate-100">{entry.title}</h3>
+                <span class="text-sm text-slate-500">{entry.period}</span>
+              </div>
+              <p class={`text-sm mb-3 ${entry.current ? 'text-emerald-400' : 'text-slate-400'}`}>
+                {entry.company} · {entry.location}
+              </p>
+              <ul class="text-slate-400 text-sm space-y-2 list-disc list-inside leading-relaxed">
+                {entry.bullets.map(b => <li>{b}</li>)}
+              </ul>
+            </div>
+          )
         ))}
       </div>
     </div>

--- a/src/skins/Light.astro
+++ b/src/skins/Light.astro
@@ -1,6 +1,7 @@
 ---
 import Layout from '../layouts/Layout.astro';
 import SkinDrawer from '../components/SkinDrawer.astro';
+import PromotionGroup from '../components/PromotionGroup.astro';
 import { personal, about, skills, experience, education, gameDev, hobbies } from '../data/content';
 ---
 
@@ -81,20 +82,34 @@ import { personal, about, skills, experience, education, gameDev, hobbies } from
     <div class="max-w-5xl mx-auto">
       <h2 class="text-3xl font-bold mb-16 text-slate-900">Experience</h2>
       <div class="space-y-10">
-        {experience.map(job => (
-          <div class={`border-l-2 pl-6 ${job.current ? 'border-emerald-500' : 'border-slate-200'}`}>
-            <div class="flex items-start justify-between gap-4 flex-wrap mb-1">
-              <h3 class="text-lg font-semibold text-slate-900">{job.title}</h3>
-              <span class="text-sm text-slate-400">{job.period}</span>
+        {experience.map(entry => (
+          entry.type === 'promotion' ? (
+            <div class={`border-l-2 pl-6 ${entry.current ? 'border-emerald-500' : 'border-slate-200'}`}>
+              <PromotionGroup
+                group={entry}
+                titleClass="text-lg font-semibold text-slate-900"
+                companyClass={entry.current ? 'text-emerald-600' : 'text-slate-500'}
+                periodClass="text-sm text-slate-400"
+                bulletClass="text-slate-500"
+                prevRoleClass="text-slate-500"
+                connectorLineClass="border-slate-200"
+                badgeClass="text-slate-400 border border-slate-200"
+              />
             </div>
-            <p class={`text-sm ${job.promotion ? 'mb-1' : 'mb-3'} ${job.current ? 'text-emerald-600' : 'text-slate-500'}`}>
-              {job.company} · {job.location}
-            </p>
-            {job.promotion && <p class="text-xs text-slate-400 mb-3">{job.promotion}</p>}
-            <ul class="text-slate-500 text-sm space-y-2 list-disc list-inside leading-relaxed">
-              {job.bullets.map(b => <li>{b}</li>)}
-            </ul>
-          </div>
+          ) : (
+            <div class={`border-l-2 pl-6 ${entry.current ? 'border-emerald-500' : 'border-slate-200'}`}>
+              <div class="flex items-start justify-between gap-4 flex-wrap mb-1">
+                <h3 class="text-lg font-semibold text-slate-900">{entry.title}</h3>
+                <span class="text-sm text-slate-400">{entry.period}</span>
+              </div>
+              <p class={`text-sm mb-3 ${entry.current ? 'text-emerald-600' : 'text-slate-500'}`}>
+                {entry.company} · {entry.location}
+              </p>
+              <ul class="text-slate-500 text-sm space-y-2 list-disc list-inside leading-relaxed">
+                {entry.bullets.map(b => <li>{b}</li>)}
+              </ul>
+            </div>
+          )
         ))}
       </div>
     </div>

--- a/src/skins/Matrix.astro
+++ b/src/skins/Matrix.astro
@@ -1,6 +1,7 @@
 ---
 import Layout from '../layouts/Layout.astro';
 import SkinDrawer from '../components/SkinDrawer.astro';
+import PromotionGroup from '../components/PromotionGroup.astro';
 import { personal, about, skills, experience, education, gameDev, hobbies } from '../data/content';
 ---
 
@@ -146,20 +147,34 @@ import { personal, about, skills, experience, education, gameDev, hobbies } from
       <p class="font-mono text-xs m-dim mb-1">$ cat experience.log</p>
       <h2 class="m-heading text-3xl font-bold mb-16">// Experience</h2>
       <div class="space-y-6">
-        {experience.map(job => (
-          <div class={`p-6 ${job.current ? 'm-card-active' : 'm-card'}`}>
-            <div class="flex items-start justify-between gap-4 flex-wrap mb-2">
-              <h3 class={`text-sm font-mono font-bold uppercase tracking-wider ${job.current ? 'm-bright' : 'm-text'}`}>{job.title}</h3>
-              <span class="text-xs font-mono m-dim border border-[#003b00] px-2 py-0.5">{job.period}</span>
+        {experience.map(entry => (
+          entry.type === 'promotion' ? (
+            <div class={`p-6 ${entry.current ? 'm-card-active' : 'm-card'}`}>
+              <PromotionGroup
+                group={entry}
+                titleClass={`text-sm font-mono font-bold uppercase tracking-wider ${entry.current ? 'm-bright' : 'm-text'}`}
+                companyClass={entry.current ? 'm-text font-mono text-xs' : 'm-dim font-mono text-xs'}
+                periodClass="text-xs font-mono m-dim"
+                bulletClass="m-mid font-mono text-xs"
+                prevRoleClass="m-dim font-mono text-xs uppercase tracking-wider"
+                connectorLineClass="border-[#003b00]"
+                badgeClass="font-mono m-dim border border-[#003b00]"
+              />
             </div>
-            <p class={`text-xs font-mono ${job.promotion ? 'mb-1' : 'mb-4'} ${job.current ? 'm-text' : 'm-dim'}`}>
-              {job.company} :: {job.location}
-            </p>
-            {job.promotion && <p class="text-xs font-mono m-dim mb-4">{job.promotion}</p>}
-            <ul class="m-mid text-xs font-mono space-y-2 leading-relaxed">
-              {job.bullets.map(b => <li class="flex gap-2"><span class="m-dim">-&gt;</span><span>{b}</span></li>)}
-            </ul>
-          </div>
+          ) : (
+            <div class={`p-6 ${entry.current ? 'm-card-active' : 'm-card'}`}>
+              <div class="flex items-start justify-between gap-4 flex-wrap mb-2">
+                <h3 class={`text-sm font-mono font-bold uppercase tracking-wider ${entry.current ? 'm-bright' : 'm-text'}`}>{entry.title}</h3>
+                <span class="text-xs font-mono m-dim border border-[#003b00] px-2 py-0.5">{entry.period}</span>
+              </div>
+              <p class={`text-xs font-mono mb-4 ${entry.current ? 'm-text' : 'm-dim'}`}>
+                {entry.company} :: {entry.location}
+              </p>
+              <ul class="m-mid text-xs font-mono space-y-2 leading-relaxed">
+                {entry.bullets.map(b => <li class="flex gap-2"><span class="m-dim">-&gt;</span><span>{b}</span></li>)}
+              </ul>
+            </div>
+          )
         ))}
       </div>
     </div>

--- a/src/skins/Motion.astro
+++ b/src/skins/Motion.astro
@@ -1,6 +1,7 @@
 ---
 import Layout from '../layouts/Layout.astro';
 import SkinDrawer from '../components/SkinDrawer.astro';
+import PromotionGroup from '../components/PromotionGroup.astro';
 import { personal, about, skills, experience, education, gameDev, hobbies } from '../data/content';
 ---
 
@@ -124,20 +125,34 @@ import { personal, about, skills, experience, education, gameDev, hobbies } from
     <div class="max-w-5xl mx-auto">
       <h2 class="reveal text-3xl font-bold mb-16 text-white">Experience</h2>
       <div class="space-y-6 stagger">
-        {experience.map(job => (
-          <div class={`reveal lift rounded-xl p-6 border ${job.current ? 'bg-cyan-500/5 border-cyan-500/20' : 'bg-white/5 border-white/10'}`}>
-            <div class="flex items-start justify-between gap-4 flex-wrap mb-1">
-              <h3 class="text-lg font-semibold text-white">{job.title}</h3>
-              <span class="text-sm text-slate-500 font-mono">{job.period}</span>
+        {experience.map(entry => (
+          entry.type === 'promotion' ? (
+            <div class={`reveal lift rounded-xl p-6 border ${entry.current ? 'bg-cyan-500/5 border-cyan-500/20' : 'bg-white/5 border-white/10'}`}>
+              <PromotionGroup
+                group={entry}
+                titleClass="text-lg font-semibold text-white"
+                companyClass={entry.current ? 'text-cyan-400' : 'text-slate-500'}
+                periodClass="text-sm text-slate-500 font-mono"
+                bulletClass="text-slate-400"
+                prevRoleClass="text-slate-500"
+                connectorLineClass="border-white/10"
+                badgeClass="text-slate-600 border border-white/10"
+              />
             </div>
-            <p class={`text-sm ${job.promotion ? 'mb-1' : 'mb-4'} ${job.current ? 'text-cyan-400' : 'text-slate-500'}`}>
-              {job.company} · {job.location}
-            </p>
-            {job.promotion && <p class="text-xs text-slate-600 mb-4">{job.promotion}</p>}
-            <ul class="text-slate-400 text-sm space-y-2 list-disc list-inside leading-relaxed">
-              {job.bullets.map(b => <li>{b}</li>)}
-            </ul>
-          </div>
+          ) : (
+            <div class={`reveal lift rounded-xl p-6 border ${entry.current ? 'bg-cyan-500/5 border-cyan-500/20' : 'bg-white/5 border-white/10'}`}>
+              <div class="flex items-start justify-between gap-4 flex-wrap mb-1">
+                <h3 class="text-lg font-semibold text-white">{entry.title}</h3>
+                <span class="text-sm text-slate-500 font-mono">{entry.period}</span>
+              </div>
+              <p class={`text-sm mb-4 ${entry.current ? 'text-cyan-400' : 'text-slate-500'}`}>
+                {entry.company} · {entry.location}
+              </p>
+              <ul class="text-slate-400 text-sm space-y-2 list-disc list-inside leading-relaxed">
+                {entry.bullets.map(b => <li>{b}</li>)}
+              </ul>
+            </div>
+          )
         ))}
       </div>
     </div>

--- a/src/skins/Retro.astro
+++ b/src/skins/Retro.astro
@@ -1,6 +1,7 @@
 ---
 import Layout from '../layouts/Layout.astro';
 import SkinDrawer from '../components/SkinDrawer.astro';
+import PromotionGroup from '../components/PromotionGroup.astro';
 import { personal, about, skills, experience, education, gameDev, hobbies } from '../data/content';
 ---
 
@@ -172,20 +173,34 @@ import { personal, about, skills, experience, education, gameDev, hobbies } from
       <div class="badge mb-4">LEVEL 03</div>
       <h2 class="retro-heading text-3xl mb-16">Experience</h2>
       <div class="space-y-6">
-        {experience.map(job => (
-          <div class={`p-6 bg-[#0d0d2b] ${job.current ? 'pixel-border' : 'border-2 border-[#1a1a40]'}`}>
-            <div class="flex items-start justify-between gap-4 flex-wrap mb-2">
-              <h3 class="text-sm font-mono font-bold text-[#ffe600] uppercase tracking-wider">{job.title}</h3>
-              <span class="text-xs font-mono text-[#ff2d78] border border-[#ff2d78]/30 px-2 py-0.5">{job.period}</span>
+        {experience.map(entry => (
+          entry.type === 'promotion' ? (
+            <div class={`p-6 bg-[#0d0d2b] ${entry.current ? 'pixel-border' : 'border-2 border-[#1a1a40]'}`}>
+              <PromotionGroup
+                group={entry}
+                titleClass="text-sm font-mono font-bold text-[#ffe600] uppercase tracking-wider"
+                companyClass={entry.current ? 'text-[#ff2d78] font-mono text-xs' : 'text-[#e8e8f0]/40 font-mono text-xs'}
+                periodClass="text-xs font-mono text-[#ff2d78]"
+                bulletClass="text-[#e8e8f0]/60 font-mono text-xs"
+                prevRoleClass="text-[#e8e8f0]/40 font-mono uppercase tracking-wider"
+                connectorLineClass="border-[#ff2d78]/20"
+                badgeClass="text-[#e8e8f0]/30 font-mono border border-[#ff2d78]/20"
+              />
             </div>
-            <p class={`text-xs font-mono ${job.promotion ? 'mb-1' : 'mb-4'} ${job.current ? 'text-[#ff2d78]' : 'text-[#e8e8f0]/40'}`}>
-              {job.company} · {job.location}
-            </p>
-            {job.promotion && <p class="text-xs font-mono text-[#e8e8f0]/30 mb-4">{job.promotion}</p>}
-            <ul class="text-[#e8e8f0]/60 text-xs font-mono space-y-2 leading-relaxed">
-              {job.bullets.map(b => <li class="flex gap-2"><span class="text-[#ff2d78]">&#9658;</span><span>{b}</span></li>)}
-            </ul>
-          </div>
+          ) : (
+            <div class={`p-6 bg-[#0d0d2b] ${entry.current ? 'pixel-border' : 'border-2 border-[#1a1a40]'}`}>
+              <div class="flex items-start justify-between gap-4 flex-wrap mb-2">
+                <h3 class="text-sm font-mono font-bold text-[#ffe600] uppercase tracking-wider">{entry.title}</h3>
+                <span class="text-xs font-mono text-[#ff2d78] border border-[#ff2d78]/30 px-2 py-0.5">{entry.period}</span>
+              </div>
+              <p class={`text-xs font-mono mb-4 ${entry.current ? 'text-[#ff2d78]' : 'text-[#e8e8f0]/40'}`}>
+                {entry.company} · {entry.location}
+              </p>
+              <ul class="text-[#e8e8f0]/60 text-xs font-mono space-y-2 leading-relaxed">
+                {entry.bullets.map(b => <li class="flex gap-2"><span class="text-[#ff2d78]">&#9658;</span><span>{b}</span></li>)}
+              </ul>
+            </div>
+          )
         ))}
       </div>
     </div>


### PR DESCRIPTION
Closes #2

## Summary
- Added `RegularJob` / `PromotionGroup` / `ExperienceEntry` discriminated union types — promotion relationship is now explicit in the data model, not inferred from a string
- Restructured Kahuna entry as a `PromotionGroup` with two explicit roles: Software Engineer (Dec 2024 - Dec 2025) and Software Engineer II (Dec 2025 - Present)
- Created `src/components/PromotionGroup.astro`: shared component that renders the current role, a dashed connector with a centered **Promoted** badge, then the previous role title and period
- Updated all 8 skins to branch on `entry.type === 'promotion'` and delegate to the shared component with skin-appropriate style props — regular job entries render unchanged

## Test plan
- [ ] Visual check across all 8 skins via the skin drawer
- [ ] Kahuna renders as a grouped promotion block (SE II + connector + SE)
- [ ] All other jobs render unchanged
- [ ] Connector and badge style fits each skin's color scheme

🤖 Generated with [Claude Code](https://claude.com/claude-code)