### PR TITLE
Hide outdated mission statement and hobbies sections

### DIFF
--- a/src/skins/Matrix.astro
+++ b/src/skins/Matrix.astro
@@ -115,10 +115,12 @@ import { personal, about, skills, experience, education, gameDev, hobbies } from
           <p class="font-mono text-xs m-dim mb-4">// who_i_am.md</p>
           {about.who.map(p => <p class="m-mid font-mono text-sm leading-relaxed mb-4">{p}</p>)}
         </div>
+        {/* #23 — hidden pending content update (see #24)
         <div class="m-card p-8">
           <p class="font-mono text-xs m-dim mb-4">// mission.md</p>
           {about.mission.map(p => <p class="m-mid font-mono text-sm leading-relaxed mb-4">{p}</p>)}
         </div>
+        */}
       </div>
     </div>
   </section>
@@ -218,6 +220,7 @@ import { personal, about, skills, experience, education, gameDev, hobbies } from
     </div>
   </section>
 
+  {/* #25 — hidden pending content update (see #26)
   <!-- HOBBIES -->
   <section id="hobbies-matrix" class="py-10 md:py-16 px-6">
     <div class="max-w-5xl mx-auto">
@@ -234,6 +237,7 @@ import { personal, about, skills, experience, education, gameDev, hobbies } from
       </div>
     </div>
   </section>
+  */}
 
   <!-- CONTACT -->
   <section id="contact-matrix" class="py-10 md:py-16 px-6">


### PR DESCRIPTION
Both sections have outdated content and need rewriting before they should be visible on the live site. Markup is preserved intact, commented out with issue references, ready to restore when updates land.

## Changes
- Commented out mission statement card in About section (`#23`)
- Commented out Hobbies section (`#25`)

## References
- Content update tracked in #24 (mission statement) and #26 (hobbies)

Closes #23, closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)