### PR TITLE
fix: GPA on its own line in education card

### DIFF
--- a/src/skins/Matrix.astro
+++ b/src/skins/Matrix.astro
@@ -203,7 +203,8 @@ import { personal, about, skills, experience, education, gameDev, hobbies } from
           <h3 class="text-sm font-mono font-bold m-bright uppercase">{education.school}</h3>
           <span class="text-xs font-mono m-dim border m-border-dim px-2 py-0.5">GRAD {education.graduated}</span>
         </div>
-        <p class="text-xs font-mono m-text mb-1">{education.degree} :: GPA {education.gpa}</p>
+        <p class="text-xs font-mono m-text">{education.degree}</p>
+        <p class="text-xs font-mono m-text mb-1">GPA {education.gpa}</p>
         <p class="m-dim text-xs font-mono">{education.minors}</p>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Splits degree and GPA onto separate lines in the Matrix skin education card
- Closes #35

## Test plan
- [ ] Visual check on Matrix skin education section (mobile + desktop)