### PR TITLE
feat: auto-add new issues to Personal Site project board

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,14 @@
+name: Add issues to project
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  add-to-project:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v1.0.2
+        with:
+          project-url: https://github.com/users/dberardi2020/projects/6
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}


### PR DESCRIPTION
Closes #37

Adds a GitHub Actions workflow that automatically adds any new issue to the Personal Site project board — no manual steps needed after the one-time setup below.

---

## Before merging: one-time setup required

The workflow uses a Personal Access Token (PAT) because GitHub's built-in token doesn't have permission to write to personal project boards. You need to create one and store it as a secret.

### Step 1 - Create a PAT

1. Go to https://github.com/settings/tokens
2. Click **Generate new token (classic)**
3. Give it a name like `add-to-project`
4. Under **Scopes**, check **`project`**
5. Click **Generate token** and copy it — you won't see it again

### Step 2 - Add it as a repo secret

1. Go to https://github.com/dberardi2020/personal-site/settings/secrets/actions
2. Click **New repository secret**
3. Name: `ADD_TO_PROJECT_PAT`
4. Value: paste the token from Step 1
5. Click **Add secret**

### Step 3 - Merge this PR

Once the secret is in place, merge this PR. Any issue opened after that will automatically appear on the board.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)